### PR TITLE
fix: add restriction base element and differ between string and number for fixed attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axah/wsdl-typegen",
-  "version": "0.0.11",
+  "version": "1.0.0",
   "main": "lib/index.js",
   "license": "MIT",
   "bin": "lib/index.js",

--- a/src/helpers/is-string-type.ts
+++ b/src/helpers/is-string-type.ts
@@ -1,0 +1,13 @@
+import resolveNs from '../utils/resolve-ns';
+
+export default function isStringType(
+  qName: string,
+  el: any,
+  options: any,
+): boolean {
+  const [nsAlias, local] = qName.split(':');
+  const nsUri = resolveNs(nsAlias, el);
+  return nsUri === 'http://www.w3.org/2001/XMLSchema' && local === 'string'
+    ? options.fn(this)
+    : options.inverse(this);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import hasNoChild from './helpers/has-no-child';
 import eachOfType from './helpers/each-of-type';
 import asComment from './helpers/as-comment';
 import ifOptional from './helpers/if-optional';
+import isStringType from './helpers/is-string-type';
 
 const glob = promisify(globRaw);
 
@@ -322,6 +323,7 @@ commander
 
                 return options.fn({ portType });
               },
+              isStringType,
               ifArray,
               hasChildOfType,
               hasNoChild,

--- a/src/templates/typescript/schema-attribute.hbs
+++ b/src/templates/typescript/schema-attribute.hbs
@@ -2,9 +2,9 @@
     TODO: attribute.ref
 {{else}}
     {{$.name.value}}{{#ifAttributeOptional this ~}}?{{/ifAttributeOptional ~}}:
-{{! TODO: fixed might be a number... }}
 {{#if $.fixed ~}}
-    '{{$.fixed.value}}'{{#ifAttributeOptional this ~}}| null | undefined{{/ifAttributeOptional ~}};
+    {{#isStringType $.type.value this}}'{{/isStringType}}{{$.fixed.value}}{{#isStringType $.type.value this}}'{{/isStringType}}
+    {{#ifAttributeOptional this ~}}| null | undefined{{/ifAttributeOptional ~}};
 {{else}}
 {{#if $.type ~}}{{typeName $.type.value this}}{{#ifAttributeOptional
         this}}| null | undefined{{/ifAttributeOptional}};{{/if}}

--- a/src/templates/typescript/schema-complex-type.hbs
+++ b/src/templates/typescript/schema-complex-type.hbs
@@ -6,7 +6,7 @@
 {{#eachOfType $children 'http://www.w3.org/2001/XMLSchema' 'complexContent'}}
 {{! TODO: print annotations as comments in the right location }}
     {{#eachOfType $children 'http://www.w3.org/2001/XMLSchema' 'restriction'}}
-        {
+        {{typeName $.base.value this ~}} & {
         {{#eachOfType $children 'http://www.w3.org/2001/XMLSchema' 'group'}}
             TODO: group
         {{/eachOfType}}

--- a/test/wsdl/calc/calc.wsdl
+++ b/test/wsdl/calc/calc.wsdl
@@ -15,6 +15,21 @@
   xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
   <wsdl:types>
     <xsd:schema targetNamespace="http://Example.org" elementFormDefault="qualified" >
+  <xsd:complexType name="Operation">
+      <xsd:sequence/>
+      <xsd:attribute name="symbol" type="xsd:string"/>
+      <xsd:attribute name="fullDescription" type="xsd:string"/>
+      <xsd:attribute name="errorCode" type="xsd:long"/>
+  </xsd:complexType>
+  <xsd:element name="Operation" type="tns:Operation"/>
+  <xsd:complexType name="AddOperation">
+      <xsd:complexContent>
+          <xsd:restriction base="tns:Operation">
+              <xsd:attribute name="symbol" type="xsd:string" fixed="Add Operation" use="required"/>
+              <xsd:attribute name="errorCode" type="xsd:long" fixed="12" use="required"/>
+          </xsd:restriction>
+      </xsd:complexContent>
+  </xsd:complexType>        
   <xsd:element name="Add">
     <xsd:complexType>
       <xsd:sequence>

--- a/test/wsdl/calc/calc.wsdl.ts
+++ b/test/wsdl/calc/calc.wsdl.ts
@@ -1,5 +1,6 @@
 import { Client as SoapClient } from 'soap';
 
+export type Operation_element = Operation;
 export type Add_element = {
   a?: number | null | undefined;
   b?: number | null | undefined;
@@ -13,6 +14,20 @@ export type Subtract_element = {
 };
 export type SubtractResponse_element = {
   result?: number | null | undefined;
+};
+
+export type Operation = {
+  attributes?: {
+    symbol?: string | null | undefined;
+    fullDescription?: string | null | undefined;
+    errorCode?: number | null | undefined;
+  };
+};
+export type AddOperation = Operation & {
+  attributes: {
+    symbol: 'Add Operation';
+    errorCode: 12;
+  };
 };
 
 export interface Client extends SoapClient {
@@ -37,7 +52,6 @@ export interface Client extends SoapClient {
   ) => Promise<
     [ICalculator_Add_OutputMessage__parameters, string, Object, string]
   >;
-
   Subtract: (
     input: ICalculator_Subtract_InputMessage__parameters | { _xml: string },
     cb: (


### PR DESCRIPTION
Schema File from Syrius / Cent often use restrictions to add further constraints to base elements like VOKey.

The current type generation does handle restrictions but ignores the base attribute. So instead of creating a union type based on the type from the base attribute and the xsd restriction attributes only the restriction attributes are currently generated. The base attribute is ignored. 

This fix will create a union type with the base type and restriction attribute types. 
 
Further more the `fixed` attribute which can be a string or numeric type will now only be converted to string constant if type is a string 

The currently generated type is:

```
export type ZAHLUNGSMITTELDEF = {
  attributes: {
    id: string;
    type: '-209';
  };
};
```

new it will create 
```
export type ZAHLUNGSMITTELDEF = i0.VOKey & {
  attributes: {
    id: string;
    type: -209;
  };
};
``` 

```
<xs:element name="ZMDefRef" type="syrmeta:ZAHLUNGSMITTELDEF">
   <annotation xmlns="http://www.w3.org/2001/XMLSchema">
      <documentation>Zahlungsmitteldefinition</documentation>
   </annotation>
</xs:element>
```

```
<xs:complexType name="ZAHLUNGSMITTELDEF">
   <xs:complexContent>
      <xs:restriction base="syrvokey:VOKey">
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute fixed="-209" name="type" type="xs:long" use="required"/>
      </xs:restriction>
   </xs:complexContent>
</xs:complexType>
```

```
<xs:element name="VOKey" type="tns:VOKey"/>
<xs:complexType name="VOKey">
      <xs:sequence/>
      <xs:attribute name="id" type="xs:string"/>
      <xs:attribute name="internalName" type="xs:string"/>
      <xs:attribute name="key" type="xs:string"/>
      <xs:attribute name="type" type="xs:long" use="required"/>
      <xs:attribute name="origin" type="xs:string"/>
   </xs:complexType>
</xs:schema>
```


